### PR TITLE
Inject Datadog trace information into log output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'pry', group: :development
 group :test do
   gem 'actionpack', '~> 6'
   gem 'activerecord', '~> 6'
+  gem 'ddtrace', '~> 0.51'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'pry', group: :development
 group :test do
   gem 'actionpack', '~> 6'
   gem 'activerecord', '~> 6'
-  gem 'ddtrace', '~> 0.51'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -8,7 +8,7 @@ gemspec path: '..'
 group :test do
   gem 'actionpack', '~> 5.2.0'
   gem 'activerecord', '~> 5.2.0'
-
+  gem 'ddtrace', '~> 0.51'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -8,6 +8,7 @@ gemspec path: '..'
 group :test do
   gem 'actionpack', '~> 6.0.0'
   gem 'activerecord', '~> 6.0.0'
+  gem 'ddtrace', '~> 0.51'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/lib/lograge/log_subscribers/base.rb
+++ b/lib/lograge/log_subscribers/base.rb
@@ -42,7 +42,11 @@ module Lograge
         define_method(method_name) { |*_arg| {} }
       end
 
+      # rubocop:disable Metrics/MethodLength
       def datadog_trace
+        # Inject Datadog tracing information
+        # See https://docs.datadoghq.com/tracing/connect_logs_and_traces/ruby/#manual-injection
+
         # Retrieves trace information for current thread
         correlation = ::Datadog.tracer.active_correlation
 
@@ -59,6 +63,7 @@ module Lograge
           ddsource: ['ruby']
         }
       end
+      # rubocop:enable Metrics/MethodLength
 
       def extract_error(payload)
         exception_object = payload[:exception_object]

--- a/lib/lograge/version.rb
+++ b/lib/lograge/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lograge
-  VERSION = '0.2'
+  VERSION = '0.3'
 end

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -5,9 +5,9 @@ require './lib/lograge/version'
 Gem::Specification.new do |s|
   s.name        = 'lograge'
   s.version     = Lograge::VERSION
-  s.authors     = ['Mathias Meyer', 'Ben Lovell']
-  s.email       = ['meyer@paperplanes.de', 'benjamin.lovell@gmail.com']
-  s.homepage    = 'https://github.com/roidrage/lograge'
+  s.authors     = ['Thriva']
+  s.email       = ['engineering@thriva.co']
+  s.homepage    = 'https://github.com/thrivadev/lograge'
   s.summary     = "Tame Rails' multi-line logging into a single line per request"
   s.description = "Tame Rails' multi-line logging into a single line per request"
   s.license     = 'MIT'
@@ -25,6 +25,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'actionpack',    '>= 4'
   s.add_runtime_dependency 'activesupport', '>= 4'
+  s.add_runtime_dependency 'ddtrace',       '~> 0.51'
   s.add_runtime_dependency 'railties',      '>= 4'
   s.add_runtime_dependency 'request_store', '~> 1.0'
+
 end

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ddtrace',       '~> 0.51'
   s.add_runtime_dependency 'railties',      '>= 4'
   s.add_runtime_dependency 'request_store', '~> 1.0'
-
 end

--- a/spec/log_subscribers/action_cable_spec.rb
+++ b/spec/log_subscribers/action_cable_spec.rb
@@ -77,6 +77,16 @@ describe Lograge::LogSubscribers::ActionCable do
       expect(log_output[:timestamp]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/)
     end
 
+    it 'includes Datadog trace information in the log output' do
+      subscriber.perform_action(event)
+      expect(log_output[:dd][:trace_id]).to eq('0')
+      expect(log_output[:dd][:span_id]).to eq('0')
+      expect(log_output[:dd].key?(:env)).to eq(true)
+      expect(log_output[:dd][:service]).to eq('rspec')
+      expect(log_output[:dd].key?(:version)).to eq(true)
+      expect(log_output[:ddsource]).to eq(%w['ruby'])
+    end
+
     context 'when an `ActiveRecord::RecordNotFound` is raised' do
       let(:exception) do
         ActiveRecord::RecordNotFound.new('Record not found').tap do |e|

--- a/spec/log_subscribers/action_cable_spec.rb
+++ b/spec/log_subscribers/action_cable_spec.rb
@@ -84,7 +84,7 @@ describe Lograge::LogSubscribers::ActionCable do
       expect(log_output[:dd].key?(:env)).to eq(true)
       expect(log_output[:dd][:service]).to eq('rspec')
       expect(log_output[:dd].key?(:version)).to eq(true)
-      expect(log_output[:ddsource]).to eq(%w['ruby'])
+      expect(log_output[:ddsource]).to eq(%w[ruby])
     end
 
     context 'when an `ActiveRecord::RecordNotFound` is raised' do

--- a/spec/log_subscribers/action_controller_spec.rb
+++ b/spec/log_subscribers/action_controller_spec.rb
@@ -174,7 +174,7 @@ describe Lograge::LogSubscribers::ActionController do
       expect(log_output[:dd][:span_id]).to eq('0')
       expect(log_output[:dd].key?(:env)).to eq(true)
       expect(log_output[:dd][:service]).to eq('rspec')
-      expect(log_output[:ddsource]).to eq(%w['ruby'])
+      expect(log_output[:ddsource]).to eq(%w[ruby])
     end
 
     context 'when an `ActiveRecord::RecordNotFound` is raised' do

--- a/spec/log_subscribers/action_controller_spec.rb
+++ b/spec/log_subscribers/action_controller_spec.rb
@@ -168,6 +168,15 @@ describe Lograge::LogSubscribers::ActionController do
       expect(log_output[:network][:client][:ip]).to eq('127.0.0.1')
     end
 
+    it 'includes Datadog trace information in the log output' do
+      subscriber.process_action(event)
+      expect(log_output[:dd][:trace_id]).to eq('0')
+      expect(log_output[:dd][:span_id]).to eq('0')
+      expect(log_output[:dd].key?(:env)).to eq(true)
+      expect(log_output[:dd][:service]).to eq('rspec')
+      expect(log_output[:ddsource]).to eq(%w['ruby'])
+    end
+
     context 'when an `ActiveRecord::RecordNotFound` is raised' do
       let(:exception) do
         ActiveRecord::RecordNotFound.new('Record not found').tap do |e|


### PR DESCRIPTION
Inject Datadog trace information into log output using the [recommended method](https://docs.datadoghq.com/tracing/connect_logs_and_traces/ruby/#manual-injection). Whilst the `ddtrace` gem can normally perform this task by patching Lograge, it does not work on this fork due to the reset in version numbers.