### PR TITLE
BUGFIX : Change duration attribute unit from microsecond to nanosecond

### DIFF
--- a/lib/lograge/log_subscribers/action_cable.rb
+++ b/lib/lograge/log_subscribers/action_cable.rb
@@ -27,7 +27,7 @@ module Lograge
       def extract_runtimes(event, _payload)
         # Duration is in milliseconds. Datadog expects times in nanoseconds.
         # https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#performance
-        { duration: 1_000 * event.duration }
+        { duration: (1_000_000.0 * event.duration).to_i }
       end
     end
   end

--- a/lib/lograge/log_subscribers/action_controller.rb
+++ b/lib/lograge/log_subscribers/action_controller.rb
@@ -66,7 +66,8 @@ module Lograge
       def extract_runtimes(event, payload)
         # Duration is in milliseconds. Datadog expects times in nanoseconds.
         # https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#performance
-        data = { duration: 1_000 * event.duration }
+        puts event.duration.inspect, (event.duration * 1_000_000.0).to_i
+        data = { duration: (1_000_000.0 * event.duration).to_i }
         data[:view] = payload[:view_runtime].to_f.round(2) if payload.key?(:view_runtime)
         data[:db] = payload[:db_runtime].to_f.round(2) if payload.key?(:db_runtime)
         data

--- a/lib/lograge/log_subscribers/action_controller.rb
+++ b/lib/lograge/log_subscribers/action_controller.rb
@@ -66,7 +66,6 @@ module Lograge
       def extract_runtimes(event, payload)
         # Duration is in milliseconds. Datadog expects times in nanoseconds.
         # https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#performance
-        puts event.duration.inspect, (event.duration * 1_000_000.0).to_i
         data = { duration: (1_000_000.0 * event.duration).to_i }
         data[:view] = payload[:view_runtime].to_f.round(2) if payload.key?(:view_runtime)
         data[:db] = payload[:db_runtime].to_f.round(2) if payload.key?(:db_runtime)

--- a/lib/lograge/version.rb
+++ b/lib/lograge/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lograge
-  VERSION = '0.3'
+  VERSION = '0.3.1'
 end

--- a/spec/log_subscribers/action_cable_spec.rb
+++ b/spec/log_subscribers/action_cable_spec.rb
@@ -20,8 +20,8 @@ describe Lograge::LogSubscribers::ActionCable do
   let(:event) do
     ActiveSupport::Notifications::Event.new(
       'perform_action.action_cable',
-      Time.now,
-      Time.now,
+      Time.new(2021, 12, 9, 12, 35, 58, "+00:00"),
+      Time.new(2021, 12, 9, 12, 35, 59, "+00:00"),
       2,
       channel_class: 'ActionCableChannel',
       data: event_params,
@@ -69,7 +69,7 @@ describe Lograge::LogSubscribers::ActionCable do
 
     it 'includes the duration' do
       subscriber.perform_action(event)
-      expect(log_output[:duration].to_s).to match(/[.0-9]{2,6}/)
+      expect(log_output[:duration]).to eq(1_000_000_000)
     end
 
     it 'includes the timestamp' do
@@ -251,8 +251,8 @@ describe Lograge::LogSubscribers::ActionCable do
       let(:event) do
         ActiveSupport::Notifications::Event.new(
           "#{action_name}.action_cable",
-          Time.now,
-          Time.now,
+          Time.new(2021, 12, 9, 12, 35, 58, "+00:00"),
+          Time.new(2021, 12, 9, 12, 35, 59, "+00:00"),
           2,
           channel_class: 'ActionCableChannel',
           data: event_params,

--- a/spec/log_subscribers/action_cable_spec.rb
+++ b/spec/log_subscribers/action_cable_spec.rb
@@ -20,8 +20,8 @@ describe Lograge::LogSubscribers::ActionCable do
   let(:event) do
     ActiveSupport::Notifications::Event.new(
       'perform_action.action_cable',
-      Time.new(2021, 12, 9, 12, 35, 58, "+00:00"),
-      Time.new(2021, 12, 9, 12, 35, 59, "+00:00"),
+      Time.new(2021, 12, 9, 12, 35, 58, '+00:00'),
+      Time.new(2021, 12, 9, 12, 35, 59, '+00:00'),
       2,
       channel_class: 'ActionCableChannel',
       data: event_params,
@@ -251,8 +251,8 @@ describe Lograge::LogSubscribers::ActionCable do
       let(:event) do
         ActiveSupport::Notifications::Event.new(
           "#{action_name}.action_cable",
-          Time.new(2021, 12, 9, 12, 35, 58, "+00:00"),
-          Time.new(2021, 12, 9, 12, 35, 59, "+00:00"),
+          Time.new(2021, 12, 9, 12, 35, 58, '+00:00'),
+          Time.new(2021, 12, 9, 12, 35, 59, '+00:00'),
           2,
           channel_class: 'ActionCableChannel',
           data: event_params,

--- a/spec/log_subscribers/action_controller_spec.rb
+++ b/spec/log_subscribers/action_controller_spec.rb
@@ -20,8 +20,8 @@ describe Lograge::LogSubscribers::ActionController do
   let(:event) do
     ActiveSupport::Notifications::Event.new(
       'process_action.action_controller',
-      Time.now,
-      Time.now,
+      Time.new(2021, 12, 9, 12, 35, 58, "+00:00"),
+      Time.new(2021, 12, 9, 12, 35, 59, "+00:00"),
       2,
       status: 200,
       controller: 'HomeController',
@@ -75,8 +75,8 @@ describe Lograge::LogSubscribers::ActionController do
     let(:redirect_event) do
       ActiveSupport::Notifications::Event.new(
         'redirect_to.action_controller',
-        Time.now,
-        Time.now,
+        Time.new(2021, 12, 9, 12, 35, 58, "+00:00"),
+        Time.new(2021, 12, 9, 12, 35, 59, "+00:00"),
         1,
         location: 'http://example.com',
         status: 302,
@@ -94,8 +94,8 @@ describe Lograge::LogSubscribers::ActionController do
     let(:unpermitted_parameters_event) do
       ActiveSupport::Notifications::Event.new(
         'unpermitted_parameters.action_controller',
-        Time.now,
-        Time.now,
+        Time.new(2021, 12, 9, 12, 35, 58, "+00:00"),
+        Time.new(2021, 12, 9, 12, 35, 59, "+00:00"),
         1,
         keys: %w[foo bar]
       )
@@ -145,7 +145,7 @@ describe Lograge::LogSubscribers::ActionController do
 
     it 'includes the duration' do
       subscriber.process_action(event)
-      expect(log_output[:duration].to_s).to match(/[.0-9]{2,6}/)
+      expect(log_output[:duration]).to eq(1_000_000_000)
     end
 
     it 'includes the view rendering time' do

--- a/spec/log_subscribers/action_controller_spec.rb
+++ b/spec/log_subscribers/action_controller_spec.rb
@@ -20,8 +20,8 @@ describe Lograge::LogSubscribers::ActionController do
   let(:event) do
     ActiveSupport::Notifications::Event.new(
       'process_action.action_controller',
-      Time.new(2021, 12, 9, 12, 35, 58, "+00:00"),
-      Time.new(2021, 12, 9, 12, 35, 59, "+00:00"),
+      Time.new(2021, 12, 9, 12, 35, 58, '+00:00'),
+      Time.new(2021, 12, 9, 12, 35, 59, '+00:00'),
       2,
       status: 200,
       controller: 'HomeController',
@@ -75,8 +75,8 @@ describe Lograge::LogSubscribers::ActionController do
     let(:redirect_event) do
       ActiveSupport::Notifications::Event.new(
         'redirect_to.action_controller',
-        Time.new(2021, 12, 9, 12, 35, 58, "+00:00"),
-        Time.new(2021, 12, 9, 12, 35, 59, "+00:00"),
+        Time.new(2021, 12, 9, 12, 35, 58, '+00:00'),
+        Time.new(2021, 12, 9, 12, 35, 59, '+00:00'),
         1,
         location: 'http://example.com',
         status: 302,
@@ -94,8 +94,8 @@ describe Lograge::LogSubscribers::ActionController do
     let(:unpermitted_parameters_event) do
       ActiveSupport::Notifications::Event.new(
         'unpermitted_parameters.action_controller',
-        Time.new(2021, 12, 9, 12, 35, 58, "+00:00"),
-        Time.new(2021, 12, 9, 12, 35, 59, "+00:00"),
+        Time.new(2021, 12, 9, 12, 35, 58, '+00:00'),
+        Time.new(2021, 12, 9, 12, 35, 59, '+00:00'),
         1,
         keys: %w[foo bar]
       )


### PR DESCRIPTION
The `duration` method returns a value in milliseconds. Datadog expects this value to be in nanoseconds. We were incorrectly converting from milliseconds to microseconds.