### PR TITLE
PLAT-332: Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,8 @@ Rails releases. That said, Lograge _should_ work with older releases.
 In your Gemfile
 
 ```ruby
-source 'https://rubygems.pkg.github.com/thrivadev' do
-  gem 'lograge'
-end
+# Specify the latest release tag
+gem 'lograge', git: 'https://github.com/thrivadev/lograge.git', tag: 'v1.0.0' 
 ```
 
 Enable it in an initializer or the relevant environment config:


### PR DESCRIPTION
## What
- Update installation guide in README

## Why
- To avoid difficulties with installing the Thriva lograge gem the user must specify the git repo (with the latest release tag) when defining the gem in the Gemfile, so it does not conflict with the actual lograge gem.