### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v1
       - name: Build and publish gem
-        uses: gabriel-iac/publish-gem-to-github@v1.0
+        uses: thrivadev/publish-gem-to-github@v2.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           owner: thrivadev

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Rails releases. That said, Lograge _should_ work with older releases.
   - JRuby: HEAD, 9.2, 9.1
   - TruffleRuby: HEAD, 21.3
 
+Lograge doesn't work on Ruby 2.5 or older.
+
 ## Installation ##
 
 In your Gemfile

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.metadata = { 'rubygems_mfa_required' => 'true' }
 
   # NOTE(ivy): Ruby version 2.5 is the oldest syntax supported by Rubocop.
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
 
   s.files = `git ls-files lib LICENSE.txt`.split("\n")
 

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.metadata = { 'rubygems_mfa_required' => 'true' }
 
   # NOTE(ivy): Ruby version 2.5 is the oldest syntax supported by Rubocop.
-  s.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  s.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   s.files = `git ls-files lib LICENSE.txt`.split("\n")
 


### PR DESCRIPTION
## What

- Workflow broke due to this GitHub update: https://github.blog/2022-04-12-git-security-vulnerability-announced/
- We forked the original repo into the thriva account and we'll be using that moving forward for publishing gems

Ref from main repo:
Issue: https://github.com/jstastny/publish-gem-to-github/issues/8
Fix: https://github.com/jstastny/publish-gem-to-github/pull/9

---
Have a read of our [Pull Request Guide](https://github.com/thrivadev/cookbook/blob/master/guides/pull-request-guide.md) for tips and tricks on writing pull requests at Thriva.

### Required software development lifecycle checks

- [x] Changes adhere to the [Secure Software Development Policy](https://drive.google.com/file/d/11Xk4kslrcY9naQM0f5fVm0fJFTpKwQaL/view)
