### PR TITLE
Update Datadog tracing gem dependency & minimum Ruby version

### DIFF
--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -8,7 +8,7 @@ gemspec path: '..'
 group :test do
   gem 'actionpack', '~> 5.2.0'
   gem 'activerecord', '~> 5.2.0'
-  gem 'ddtrace', '~> 0.51'
+  gem 'ddtrace', '~> 1.1'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -8,7 +8,7 @@ gemspec path: '..'
 group :test do
   gem 'actionpack', '~> 6.0.0'
   gem 'activerecord', '~> 6.0.0'
-  gem 'ddtrace', '~> 0.51'
+  gem 'ddtrace', '~> 1.1'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/lib/lograge/log_subscribers/base.rb
+++ b/lib/lograge/log_subscribers/base.rb
@@ -48,7 +48,7 @@ module Lograge
         # See https://docs.datadoghq.com/tracing/connect_logs_and_traces/ruby/#manual-injection
 
         # Retrieves trace information for current thread
-        correlation = ::Datadog.tracer.active_correlation
+        correlation = ::Datadog::Tracing.correlation
 
         {
           # Adds IDs as tags to log output

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'actionpack',    '>= 4'
   s.add_runtime_dependency 'activesupport', '>= 4'
-  s.add_runtime_dependency 'ddtrace',       '~> 0.51'
+  s.add_runtime_dependency 'ddtrace',       '~> 1.1'
   s.add_runtime_dependency 'railties',      '>= 4'
   s.add_runtime_dependency 'request_store', '~> 1.0'
 end

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
 
   s.metadata = { 'rubygems_mfa_required' => 'true' }
 
-  # NOTE(ivy): Ruby version 2.5 is the oldest syntax supported by Rubocop.
   s.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   s.files = `git ls-files lib LICENSE.txt`.split("\n")


### PR DESCRIPTION
* Update to at least version `1.1` of the [dd-trace-rb](https://github.com/DataDog/dd-trace-rb) gem.
* Bump minimum Ruby version (Rubocop's default target Ruby version is now 2.6)