### PR TITLE
Add functionality to optionally log request parameters.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,12 @@
 AllCops:
+  TargetRubyVersion: 2.7
   Exclude:
     - Guardfile
     - vendor/**/*
   NewCops: enable
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
 
 Layout/LineLength:
   Max: 120

--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -97,6 +97,9 @@ module Lograge
   mattr_accessor :log_level
   self.log_level = :info
 
+  mattr_accessor :log_request_params
+  self.log_request_params = false
+
   # The emitted log format
   #
   # Currently supported formats are>


### PR DESCRIPTION
Allow applications to opt into logging request parameters in both the fulltext searchable `message` attribute and the the embedded `params` attribute.